### PR TITLE
feature-cb-30152 - Rebuild and repackage Yara 2.1.1

### DIFF
--- a/cb-yara-connector
+++ b/cb-yara-connector
@@ -9,11 +9,27 @@ piddir="/run/cb/integrations/$prog"
 pidfile="$piddir/$prog.pid"
 logdir="/var/log/cb/integrations/$prog"
 logfile="$logdir/$prog.startup.log"
+# 5 Seconds for yara to startup.
+running_check_retries=20
+running_check_wait=0.25
 
 command="/usr/share/cb/integrations/cb-yara-connector/yaraconnector --pid-file $pidfile --working-dir /usr/share/cb/integrations/cb-yara-connector --config-file /etc/cb/integrations/cb-yara-connector/yaraconnector.conf --daemon --log-file $logdir/cb-yara-connector.log --output-file /var/cb/data/cb-yara-connector/feed.json"
 
 is_running() {
     [ -f "$pidfile" ] && kill -0 $(cat "$pidfile") 2> /dev/null
+}
+
+is_running_retry() {
+    retry_count=0
+    while [ $retry_count -le $running_check_retries ]
+    do
+        if is_running; then
+            return 0 # Return true
+        fi
+        sleep $running_check_wait
+        retry_count=$[$retry_count + 1]
+    done
+    return 1 # Return false
 }
 
 start() {
@@ -28,7 +44,7 @@ start() {
     $command &> $logfile
     result=$?
 
-    if is_running; then
+    if is_running_retry; then
         echo "Ok"
     else
         echo "Failed"

--- a/cb-yara-connector
+++ b/cb-yara-connector
@@ -41,6 +41,7 @@ start() {
     mkdir -p $piddir
     rm -f $pidfile 2> /dev/null
     echo -n "Starting $prog: "
+    export C_FORCE_ROOT=1
     $command &> $logfile
     result=$?
 
@@ -55,7 +56,9 @@ start() {
 stop() {
     echo -n "Shutting down $prog: "
     if is_running; then
-        kill -s SIGTERM $(cat $pidfile) && rm -f $pidfile 2> /dev/null
+        pid=$(cat $pidfile)
+        pgid=$(ps -o pgid --pid $pid --no-heading)
+        pkill -15 -g $pgid && rm -f $pidfile 2> /dev/null
         echo "Ok"
         return 0
     fi

--- a/cb-yara-connector
+++ b/cb-yara-connector
@@ -13,7 +13,7 @@ logfile="$logdir/$prog.startup.log"
 running_check_retries=20
 running_check_wait=0.25
 
-command="/usr/share/cb/integrations/cb-yara-connector/yaraconnector --pid-file $pidfile --working-dir /usr/share/cb/integrations/cb-yara-connector --config-file /etc/cb/integrations/cb-yara-connector/yaraconnector.conf --daemon --log-file $logdir/cb-yara-connector.log --output-file /var/cb/data/cb-yara-connector/feed.json"
+command="/usr/share/cb/integrations/cb-yara-connector/yaraconnector --pid-file $pidfile --working-dir /usr/share/cb/integrations/cb-yara-connector --config-file /etc/cb/integrations/cb-yara-connector/yaraconnector.conf --daemon --log-file $logdir/yaraconnector.log --output-file /var/cb/data/cb-yara-connector/feed.json"
 
 is_running() {
     [ -f "$pidfile" ] && kill -0 $(cat "$pidfile") 2> /dev/null

--- a/cb-yara-connector
+++ b/cb-yara-connector
@@ -8,22 +8,27 @@ prog="cb-yara-connector"
 piddir="/run/cb/integrations/$prog"
 pidfile="$piddir/$prog.pid"
 logdir="/var/log/cb/integrations/$prog"
-logfile="/$prog.startup.log"
+logfile="$logdir/$prog.startup.log"
 
 command="/usr/share/cb/integrations/cb-yara-connector/yaraconnector --pid-file $pidfile --working-dir /usr/share/cb/integrations/cb-yara-connector --config-file /etc/cb/integrations/cb-yara-connector/yaraconnector.conf --daemon --log-file $logdir/cb-yara-connector.log --output-file /var/cb/data/cb-yara-connector/feed.json"
 
+is_running() {
+    [ -f "$pidfile" ] && kill -0 $(cat "$pidfile") 2> /dev/null
+}
+
 start() {
-    if [ -f "$pidfile" ] && kill -0 $(cat "$pidfile"); then
+    if is_running; then
         echo "Already started"
         return 1
     fi
 
     mkdir -p $piddir
+    rm -f $pidfile 2> /dev/null
     echo -n "Starting $prog: "
     $command &> $logfile
     result=$?
 
-    if [ -f "$pidfile" ]; then
+    if is_running; then
         echo "Ok"
     else
         echo "Failed"
@@ -33,18 +38,19 @@ start() {
 
 stop() {
     echo -n "Shutting down $prog: "
-    if [ ! -f "$pidfile" ] || ! kill -0 $(cat "$pidfile"); then
+    if is_running; then
+        kill -s SIGTERM $(cat $pidfile) && rm -f $pidfile 2> /dev/null
         echo "Ok"
-        return 1
+        return 0
     fi
-	kill -s SIGTERM $(cat $pidfile) && rm -f $pidfile
-	echo "Ok"
-    return 0
+
+    echo "Ok"
+    return 1
 }
 
 status() {
     echo -n "Status of $prog: "
-    if [ -f "$pidfile" ] && kill -0 $(cat "$pidfile"); then
+    if is_running; then
         echo "Running"
     else
         echo "Stopped"

--- a/cb-yara-connector.rpm.spec
+++ b/cb-yara-connector.rpm.spec
@@ -42,3 +42,11 @@ touch ${RPM_BUILD_ROOT}/tmp/yaraconnectorceleryworker
 
 %files -f MANIFEST
 %config /etc/cb/integrations/cb-yara-connector/yaraconnector.conf.example
+
+%preun
+%if "%{?dist}" == ".el6"
+service cb-yara-connector stop
+%else # EL7 and up
+systemctl stop cb-yara-connector
+%endif
+

--- a/cb-yara-connector.rpm.spec
+++ b/cb-yara-connector.rpm.spec
@@ -25,7 +25,7 @@ mkdir -p ${RPM_BUILD_ROOT}/tmp
 mkdir -p ${RPM_BUILD_ROOT}/var/run/
 mkdir -p ${RPM_BUILD_ROOT}/var/cb/data/cb-yara-connector/feed_db
 
-%if "%{?dist}" == ".el6"
+%if %{defined el6}
 mkdir -p ${RPM_BUILD_ROOT}/etc/init
 mkdir -p ${RPM_BUILD_ROOT}/etc/init.d/
 install -m 700 ${RPM_SOURCE_DIR}/cb-yara-connector ${RPM_BUILD_ROOT}/etc/init.d/cb-yara-connector
@@ -44,7 +44,7 @@ touch ${RPM_BUILD_ROOT}/tmp/yaraconnectorceleryworker
 %config /etc/cb/integrations/cb-yara-connector/yaraconnector.conf.example
 
 %preun
-%if "%{?dist}" == ".el6"
+%if %{defined el6}
 service cb-yara-connector stop
 %else # EL7 and up
 systemctl stop cb-yara-connector

--- a/cb-yara-connector.rpm.spec
+++ b/cb-yara-connector.rpm.spec
@@ -1,5 +1,5 @@
 %define version 2.1.1
-%define release 1
+%define release 2
 
 Name: python-cb-yara-connector
 Version: %{version}

--- a/cb-yara-connector.service
+++ b/cb-yara-connector.service
@@ -5,7 +5,7 @@ After=syslog.target network.target
 [Service]
 Environment=C_FORCE_ROOT=1
 Type=forking
-ExecStart=/usr/share/cb/integrations/cb-yara-connector/yaraconnector --pid-file /run/cb/integrations/cb-yara-connector/cb-yara-connector.pid --config-file /etc/cb/integrations/cb-yara-connector/yaraconnector.conf --daemon --log-file /var/log/cb/integrations/cb-yara-connector/cb-yara-connector.log --output-file /var/cb/data/cb-yara-connector/feed.json
+ExecStart=/usr/share/cb/integrations/cb-yara-connector/yaraconnector --pid-file /run/cb/integrations/cb-yara-connector/cb-yara-connector.pid --config-file /etc/cb/integrations/cb-yara-connector/yaraconnector.conf --daemon --log-file /var/log/cb/integrations/cb-yara-connector/yaraconnector.log --output-file /var/cb/data/cb-yara-connector/feed.json
 PIDFile=/run/cb/integrations/cb-yara-connector/cb-yara-connector.pid
 WorkingDirectory=/usr/share/cb/integrations/cb-yara-connector
 KillSignal=SIGTERM

--- a/src/main.py
+++ b/src/main.py
@@ -707,8 +707,6 @@ def main():
     # Verify the configuration file and load up important global variables
     try:
         ConfigurationInit(args.config_file, args.output_file)
-        if not test_database_conn():
-            sys.exit(1)
     except Exception as err:
         logger.error(f"Unable to continue due to a configuration problem: {err}")
         sys.exit(1)
@@ -762,6 +760,14 @@ def main():
 
                 # Operating mode - are we the master a worker?
                 run_as_master = "master" in globals.g_mode
+
+                # noinspection PyBroadException
+                try:
+                    if run_as_master and not test_database_conn():
+                        sys.exit(1)
+                except Exception as ex:
+                    logger.error(F"Failed database connection test: {ex}")
+                    sys.exit(1)
 
                 # Signal handler
                 sig_handler = partial(handle_sig, exit_event)


### PR DESCRIPTION
CB-30152: Re-building and re-packaging Yara 2.1.1 with some service adjustments (especially for el6).

* El6 build environment was not consistent.  Not sure exactly what was built and released for Yara 2.1.1-1 for el6.
* Minor service adjustments to make service management in EL6 cleaner.
* Reverted to using yaraconnector.log instead of cb-yara-connector.log.  (via service files)