### PR TITLE
CB-31528: (also CB-32037) branding & terminology changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,5 @@ pip3 install -r requirements.txt
 * View all API and integration offerings on the [Developer Network](https://developer.carbonblack.com) along with reference documentation, video tutorials, and how-to guides.
 * Use the [Developer Community Forum](https://community.carbonblack.com/community/resources/developer-relations) to discuss issues and get answers from other API developers in the Carbon Black Community.
 * Report bugs and change requests to [Carbon Black Support](http://carbonblack.com/resources/support/).
+
+Copyright &copy; 2014-2020 VMware, Inc. All Rights Reserved.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # Installing YARA Agent (CentOS/RHEL 6/7/8)
 
-[YARA](https://virustotal.github.io/yara/) Integration is made up of two parts -- a master and one or more workers. The master service must be installed on the same system as CB EDR, while workers are usually installed on other systems (but can also be on the master system, if so desired). The YARA connector itself uses [Celery](http://www.celeryproject.org/) to distribute work to and remote (or local) workers - you will need to install and configure a [broker](https://docs.celeryproject.org/en/latest/getting-started/brokers/) (e.g., [Redis](https://redis.io/)) that is accessible to both the task-master and the remote worker instance(s).
+[YARA](https://virustotal.github.io/yara/) Integration has two parts -- a primary and one or more minions. The primary
+service must be installed on the same system as VMware CB EDR, while minions are usually installed on other systems (but 
+can also be on the primary system, if so desired). The YARA connector itself uses [Celery](http://www.celeryproject.org/) 
+to distribute work to and remote (or local) minions - you will need to install and configure a 
+[broker](https://docs.celeryproject.org/en/latest/getting-started/brokers/) (e.g., [Redis](https://redis.io/)) that is 
+accessible to both the primary and remote minion instance(s).
 
-The connector reads YARA rules from a configured directory to efficiently scan binaries as they are seen by the CB EDR server. The generated threat information is used to produce an intelligence feed for ingest by the CB EDR Server.
+The connector reads YARA rules from a configured directory to efficiently scan binaries as they are seen by the EDR server. T
+he generated threat information is used to produce an intelligence feed for ingest by the EDR Server.
 
 1. Install the CbOpenSource repository if it isn't already present:
     
@@ -21,21 +27,22 @@ The connector reads YARA rules from a configured directory to efficiently scan b
 The installation process creates a sample configuration file: `/etc/cb/integrations/cb-yara-connector/yaraconnector.conf.sample`.  Copy
 this sample template to `/etc/cb/integrations/cb-yara-connector/yaraconnector.conf`,
 which is the filename and location that the connector expects.  You will likely have to edit this
-configuration file on each system (master and workers) to supply any missing
-information:
-* There are two operating modes to support the two roles: `mode=master` and `mode=worker`. Both modes require a broker for Celery communications. Worker systems will need to change the mode to `worker`; 
-
-* Remote worker systems will require the master's URL for `cb_server_url` (local workers need no modification);
+configuration file on each system (primary and minions) to supply any missing information:
+* There are two operating modes to support the two roles: `mode=primary` and `mode=minion`. Both modes require a broker 
+for Celery communications. Minion systems will need to change the mode to `minion`; 
+* Remote minion systems will require the primary's URL for `cb_server_url` (local minions need no modification);
  they also require  the token of a global admin user for `cb_server_token`. 
-* Remote workers will require the URL of the master's Redis server 
+* Remote minions will require the URL of the primary's Redis server 
 
-The daemon will attempt to load the PostgreSQL credentials from the CB EDR server's `cb.conf` file, 
-if available, falling back to the PostgreSQL connection information in the master's configuration file using the `postgres_xxxx` keys in the config. The REST API location and credentials are specified in the `cb_server_url` and `cb_server_token` keys, respectively. 
+The daemon will attempt to load the PostgreSQL credentials from the EDR server's `cb.conf` file, 
+if available, falling back to the PostgreSQL connection information in the primary's configuration file using the 
+`postgres_xxxx` keys in the config. The REST API location and credentials are specified in the `cb_server_url` and 
+`cb_server_token` keys, respectively. 
 
 ```ini
 ;
-; Cb Response PostgreSQL Database settings, required for 'master' and 'master+worker' systems
-; The seever will attempt to read from local cb.conf file first and fall back
+; Cb Response PostgreSQL Database settings, required for 'primary' and 'primary+minion' systems
+; The server will attempt to read from local cb.conf file first and fall back
 ; to these settings if it cannot do so.
 ;
 postgres_host=127.0.0.1
@@ -47,8 +54,8 @@ postgres_port=5002
 
 ```ini
 ;
-; Cb EDR server settings, required for 'worker' and 'master+worker' systems
-; For remote workers, the cb_server_url mus be that of the master
+; EDR server settings, required for 'primary' and 'primary+minion' systems
+; For remote workers, the cb_server_url mus be that of the primary
 ;
 cb_server_url=https://127.0.0.1
 cb_server_token=<API TOKEN GOES HERE>
@@ -59,9 +66,9 @@ Set this appropriately as per the [Celery documentation](https://docs.celeryproj
 
 ```ini
 ;
-; URL of the Redis server, defaulting to the local CB EDR server Redis for the master.  If this is a worker
-; system, alter to point to the master system.  If you are using a standalone Redis server, both master and
-; workers must point to the same server.
+; URL of the Redis server, defaulting to the local EDR server Redis for the primary.  If this is a minion
+; system, alter to point to the primary system.  If you are using a standalone Redis server, both primary and
+; minions must point to the same server.
 ;
 broker_url=redis://127.0.0.1
 ```
@@ -72,7 +79,7 @@ specifying one or more YARA rule. Your rules must have `meta` section with a
 `score = [1-10]` tag to appropriately score matching binaries.  This directory is 
 configurable in your configuration file. C-style comments are supported.
 
-#### Sample YARA Rule File
+### Sample YARA Rule File
 ```
 // Sample rule to match binaries over 100kb in size
 
@@ -84,9 +91,9 @@ rule matchover100kb {
 }
 ```
 
-## Controlling the YARA Agent 
+# Controlling the YARA Agent 
 
-#### CentOS / Red Hat 6
+## CentOS / Red Hat 6
 
 | Action | Command |
 | ------ | ------- |
@@ -94,7 +101,7 @@ rule matchover100kb {
 | Stop the service | `service cb-yara-connector stop` |
 | Display service status | `service cb-yara-connector status` | 
 
-#### CentOS / Red Hat 7
+## CentOS / Red Hat 7
 
 | Action | Command |
 | ------ | ------- |
@@ -102,6 +109,45 @@ rule matchover100kb {
 | Stop the service | `systemctl stop cb-yara-connector` |
 | Display service status | `systemctl status -l cb-yara-connector` |
 | Displaying verbose logs | `journalctl -u cb-yara-connector` |
+
+## Command-line Options
+```text
+usage: yaraconnector [-h] --config-file CONFIG_FILE [--log-file LOG_FILE]
+                     [--output-file OUTPUT_FILE] [--working-dir WORKING_DIR]
+                     [--pid-file PID_FILE] [--daemon]
+                     [--validate-yara-rules] [--debug]
+
+Yara Agent for Yara Connector
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --config-file CONFIG_FILE
+                        location of the config file
+  --log-file LOG_FILE   file location for log output
+  --output-file OUTPUT_FILE
+                        file location for feed file
+  --working-dir WORKING_DIR
+                        working directory
+  --pid-file PID_FILE   pid file location - if not supplied, will not write a
+                        pid file
+  --daemon              run in daemon mode (run as a service)
+  --validate-yara-rules
+                        only validate the yara rules, then exit
+  --debug               enabled debug level logging
+```
+### --config-file
+Provides the path of the configuration file to be used _**(REQUIRED)**_
+
+### --log-file
+Provides the path of the YARA log file.  If not supplied, defaults to `local/yara_agent.log`
+within the current YARA package.
+
+### --output-file
+Provides the path containing the feed description file.  If not supplied, defaults to
+`feed.json` in the same location as the configured `feed_database_dir` folder.
+
+### --validate-yara-rules
+If supplied, YARA rules will be validated and the script will exit.
 
 # Development Notes	
 
@@ -137,48 +183,9 @@ the connector.
 
 The provided script `docker-build-rpm.sh` will use docker to build the project, and place the RPM(s) in `${PWD}/RPMS`. 
 
-
-##### Command-line Options
-```text
-usage: yaraconnector [-h] --config-file CONFIG_FILE [--log-file LOG_FILE]
-                     [--output-file OUTPUT_FILE] [--working-dir WORKING_DIR]
-                     [--pid-file PID_FILE] [--daemon]
-                     [--validate-yara-rules] [--debug]
-
-Yara Agent for Yara Connector
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --config-file CONFIG_FILE
-                        location of the config file
-  --log-file LOG_FILE   file location for log output
-  --output-file OUTPUT_FILE
-                        file location for feed file
-  --working-dir WORKING_DIR
-                        working directory
-  --pid-file PID_FILE   pid file location - if not supplied, will not write a
-                        pid file
-  --daemon              run in daemon mode (run as a service)
-  --validate-yara-rules
-                        only validate the yara rules, then exit
-  --debug               enabled debug level logging
-```
-###### --config-file
-Provides the path of the configuration file to be used _**(REQUIRED)**_
-
-###### --log-file
-Provides the path of the YARA log file.  If not supplied, defaults to `local/yara_agent.log`
-within the current YARA package.
-
-###### --output-file
-Provides the path containing the feed description file.  If not supplied, defaults to
-`feed.json` in the same location as the configured `feed_database_dir` folder.
-
-###### --validate-yara-rules
-If supplied, YARA rules will be validated and the script will exit.
-
 ---
-# Dev install 
+
+## Dev install 
 
 Use Git to retrieve the project, create a new virtual environment using Python 3.6+, and use pip to install the requirements:
 
@@ -186,3 +193,9 @@ Use Git to retrieve the project, create a new virtual environment using Python 3
 git clone https://github.com/carbonblack/cb-yara-connector
 pip3 install -r requirements.txt
 ```
+
+# Support
+
+* View all API and integration offerings on the [Developer Network](https://developer.carbonblack.com) along with reference documentation, video tutorials, and how-to guides.
+* Use the [Developer Community Forum](https://community.carbonblack.com/community/resources/developer-relations) to discuss issues and get answers from other API developers in the Carbon Black Community.
+* Report bugs and change requests to [Carbon Black Support](http://carbonblack.com/resources/support/).

--- a/cb-yara-connector.rpm.spec
+++ b/cb-yara-connector.rpm.spec
@@ -1,5 +1,5 @@
-%define version 2.1.1
-%define release 2
+%define version 2.1.2
+%define release 1
 %define _build_id_links none
 
 Name: python-cb-yara-connector

--- a/cb-yara-connector.rpm.spec
+++ b/cb-yara-connector.rpm.spec
@@ -4,14 +4,14 @@
 Name: python-cb-yara-connector
 Version: %{version}
 Release: %{release}%{?dist}
-Summary: Carbon Black Yara Agent
+Summary: VMware Carbon Black Yara Agent
 License: MIT
 BuildArch: x86_64
-Vendor: Carbon Black
+Vendor: VMware Carbon Black
 Url: http://www.carbonblack.com/
 
 %description
-Carbon Black Yara Agent - Scans binaries with configured yara rules
+VMware Carbon Black Yara Agent - Scans binaries with configured yara rules
 
 %build
 cd %_sourcedir ; pyinstaller cb-yara-connector.spec

--- a/cb-yara-connector.service
+++ b/cb-yara-connector.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Carbon Black Response Yara Connector
+Description=VMware Carbon Black Response Yara Connector
 After=syslog.target network.target
 
 [Service]

--- a/example-conf/yara-dev.conf
+++ b/example-conf/yara-dev.conf
@@ -1,5 +1,5 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Sample main and worker config file
+;; Sample primary and minion config file
 ;;
 ;; You may also use "~" if you wish to locate files or directories in your
 ;; home folder
@@ -39,7 +39,7 @@ postgres_port=5002
 ;niceness=1
 
 ;
-; Number of hashes to send to the workers concurrently.
+; Number of hashes to send to the minions concurrently.
 ; Recommend setting to the number of workers on the remote system.
 ;
 concurrent_hashes=8

--- a/example-conf/yara.conf
+++ b/example-conf/yara.conf
@@ -1,9 +1,9 @@
 [general]
 
 ;
-; Operating mode - choose 'master' for the main system, 'worker' for a remote worker.
+; Operating mode - choose 'primary' for the main system, 'minion' for a remote minion.
 ;
-mode=master
+mode=primary
 
 ;
 ; path to directory containing yara rules
@@ -11,8 +11,8 @@ mode=master
 yara_rules_dir=/etc/cb/integrations/cb-yara-connector/yara_rules
 
 ;
-; Cb Response postgres Database settings, required for 'master' systems
-; The seever will attempt to read from local cb.conf file first and fall back
+; EDR PostgreSQL database settings, required for 'primary' systems
+; The server will attempt to read from local cb.conf file first and fall back
 ; to these settings if it cannot do so.
 ;
 postgres_host=127.0.0.1
@@ -22,16 +22,16 @@ postgres_db=cb
 postgres_port=5002
 
 ;
-; Cb Response Server settings, required for 'worker' systems
-; For remote workers, the cb_server_url mus be that of the master
+; Cb Response Server settings, required for 'minion' systems
+; For remote minions, the cb_server_url must be that of the primary
 ;
 cb_server_url=https://127.0.0.1
 cb_server_token=<API TOKEN GOES HERE>
 
 ;
-; URL of the redis server, defaulting to the local response server redis for the master.  If this is a worker
-; system, alter to point to the master system.  If you are using a standalone redis server, both master and
-; workers must point to the same server
+; URL of the redis server, defaulting to the local response server redis for the primary.  If this is a minion
+; system, alter to point to the primary system.  If you are using a standalone redis server, both primary and
+; minions must point to the same server
 ;
 broker_url=redis://localhost:6379
 
@@ -42,7 +42,7 @@ niceness=1
 
 ;
 ; Number of hashes to send to the workers concurrently.  Defaults to 8.
-; Recommend setting to the number of workers on the remote system.
+; Recommend setting to the number of minions on the remote system.
 ;
 concurrent_hashes=8
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 # noinspection PyUnusedName
 __author__ = "Carbon Black"

--- a/src/analysis_result.py
+++ b/src/analysis_result.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 
 class AnalysisResult(object):

--- a/src/binary_database.py
+++ b/src/binary_database.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import logging
 

--- a/src/celery_app.py
+++ b/src/celery_app.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 
 from celery import Celery

--- a/src/config_handling.py
+++ b/src/config_handling.py
@@ -19,6 +19,17 @@ __all__ = ["ConfigurationInit"]
 
 ################################################################################
 # Configuration reader/validator
+#
+# Note: As of version 2.1.2, some terminology changes have been made that
+# affects one configuration parameter, and the values used for the "mode"
+# parameter. Some previous terms are now deprecated, but are still honored
+# at runtime for compatibility, so that existing configuration file will continue
+# to work:
+#
+#   - the parameter 'worker_network_timeout' os now 'minion_network_timeout'
+#   - for the 'mode' parameter, the values "master", "worker" and "master+worker"
+#     are now "primary", "minion" and "primary+minion"
+#
 ################################################################################
 
 # Known parameters -- flag others as potential typos!

--- a/src/config_handling.py
+++ b/src/config_handling.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import configparser
 import json
@@ -49,7 +49,7 @@ KNOWN = [
 
 MODES = [
     "master", "primary",
-    "worker", "minion"
+    "worker", "minion",
     "master+worker", "primary+minion"
 ]
 

--- a/src/config_handling.py
+++ b/src/config_handling.py
@@ -43,20 +43,27 @@ KNOWN = [
     "utility_interval",
     "utility_script",
     "worker_network_timeout",
+    "minion_network_timeout",
     "yara_rules_dir",
 ]
 
+MODES = [
+    "master", "primary",
+    "worker", "minion"
+    "master+worker", "primary+minion"
+]
 
 class ConfigurationInit(object):
     """
     Class to deal with all configuration loading and validation.
     """
+    ALLOWED_MODES = []
 
     def __init__(self, config_file: str, output_file: str = None, **kwargs) -> None:
         """
         Validate the config file.
         :param config_file: The config file to validate
-        :param output_file: the output file; if not specified assume we are a task worker (simplified validation)
+        :param output_file: the output file; if not specified assume we are a task minion (simplified validation)
         """
         self.abs_config = os.path.abspath(os.path.expanduser(config_file))
         self.source = f"Config file '{self.abs_config}'"
@@ -92,25 +99,29 @@ class ConfigurationInit(object):
         except configparser.InterpolationSyntaxError as err:
             raise CbInvalidConfig(f"{self.source} cannot be parsed: {err}")
 
-        globals.g_mode = self._as_str("mode", required=False, default="master",
-                                      allowed=["master", "worker", "master+worker"])
+        globals.g_mode = self._as_str("mode",
+                                      required=False,
+                                      default="primary",
+                                      allowed=MODES)
 
         # do the config checks
-        self._worker_check()
+        self._minion_check()
 
-        if globals.g_mode in ["master", "master+worker"]:
-            self._master_check(output_file)
+        if globals.g_mode in MODES:
+            self._primary_check(output_file)
 
-    def _worker_check(self) -> None:
+    def _minion_check(self) -> None:
         """
-        Validate entries used by task workers as well as the main process.
+        Validate entries used by task minions as well as the main process.
 
         :raises CbInvalidConfig:
         """
         globals.g_yara_rules_dir = self._as_path("yara_rules_dir", required=True, check_exists=True, expect_dir=True)
 
-        # we need the cb_server_api information whenever  required (ie, we are a worker)
-        cb_req = "worker" in globals.g_mode or "master+worker" in globals.g_mode
+        # we need the cb_server_api information whenever required (ie, we are a minion)
+        cb_req = False
+        if globals.g_mode in MODES:
+            cb_req = True
 
         globals.g_cb_server_url = self._as_str("cb_server_url", required=cb_req)
         globals.g_cb_server_token = self._as_str("cb_server_token", required=cb_req)
@@ -118,11 +129,17 @@ class ConfigurationInit(object):
         value = self._as_str("broker_url", required=True)
         app.conf.update(broker_url=value, result_backend=value)
 
-        globals.g_worker_network_timeout = self._as_int("worker_network_timeout",
-                                                        default=globals.g_worker_network_timeout)
-        globals.g_celeryworkerkwargs = self._as_json("celery_worker_kwargs")
+        # newer terminology takes precedence
+        globals.g_minion_network_timeout = self._as_int("worker_network_timeout",
+                                                        default=globals.g_minion_network_timeout)
+        globals.g_minion_network_timeout = self._as_int("minion_network_timeout",
+                                                        default=globals.g_minion_network_timeout)
 
-    def _master_check(self, output_file) -> None:
+        # newer terminology takes precedence
+        globals.g_celery_worker_kwargs = self._as_json("celery_worker_kwargs")
+        globals.g_celery_worker_kwargs = self._as_json("celery_worker_kwargs")
+
+    def _primary_check(self, output_file) -> None:
         """
         Validate entries used by the main process.
 
@@ -201,7 +218,11 @@ class ConfigurationInit(object):
 
     # ----- Type Handlers ------------------------------------------------------------
 
-    def _as_str(self, param: str, required: bool = False, default: str = "", allowed: List[str] = None) -> str:
+    def _as_str(self,
+                param: str,
+                required: bool = False,
+                default: str = "",
+                allowed: List[str] = None) -> str:
         """
         Get a string parameter from the configuration.
 
@@ -229,8 +250,13 @@ class ConfigurationInit(object):
 
         return value
 
-    def _as_path(self, param: str, required: bool = False, check_exists: bool = True, expect_dir: bool = False,
-                 default: str = "", create_if_needed: bool = False) -> str:
+    def _as_path(self,
+                 param: str,
+                 required: bool = False,
+                 check_exists: bool = True,
+                 expect_dir: bool = False,
+                 default: str = "",
+                 create_if_needed: bool = False) -> str:
         """
         Get a string parameter from the configuration and treat it as a path, performing normalization
         to produce an absolute path.  a "~/" at the beginning will be treated as the current user's home
@@ -268,7 +294,11 @@ class ConfigurationInit(object):
                             f"{self.source} specified path parameter '{param}' ({value}) does not exist")
             return value
 
-    def _as_int(self, param: str, required: bool = False, default: int = -1, min_value: int = None) -> int:
+    def _as_int(self,
+                param: str,
+                required: bool = False,
+                default: int = -1,
+                min_value: int = None) -> int:
         """
         Get an integer configuration parameter from the configuration.  A parameter that cannot be converted
         to an int will return a ValueError.
@@ -288,7 +318,10 @@ class ConfigurationInit(object):
         return value
 
     # noinspection PySameParameterValue
-    def _as_bool(self, param: str, required: bool = False, default: bool = False) -> Optional[bool]:
+    def _as_bool(self,
+                 param: str,
+                 required: bool = False,
+                 default: bool = False) -> Optional[bool]:
         """
         Get a boolean configuration parameter from the configuration.  A parameter not one of
         ["true", "yes", "false", "no"] will return a ValueError.
@@ -310,7 +343,9 @@ class ConfigurationInit(object):
             return value if value is None else value.lower() in ["true", "yes"]
 
     # noinspection PySameParameterValue
-    def _as_json(self, param: str, required: bool = False) -> Optional[dict]:
+    def _as_json(self,
+                 param: str,
+                 required: bool = False) -> Optional[dict]:
         """
         Get a single-line JSON string and convert to a python dict for use as a kwargs.
         :param param: Name of the configuration parameter

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 
 class CbException(Exception):

--- a/src/feed.py
+++ b/src/feed.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import base64
 import binascii

--- a/src/globals.py
+++ b/src/globals.py
@@ -11,8 +11,8 @@ g_output_file = ""
 g_yara_rule_map = {}
 g_yara_rule_map_hash_list = []
 
-# configuiration
-g_mode = "master"
+# configuration
+g_mode = "primary"
 
 g_cb_server_url = ""
 g_cb_server_token = ""
@@ -40,6 +40,6 @@ g_utility_interval = 0
 g_utility_script = ""
 g_utility_debug = False  # dev use only, reduces interval from minutes to seconds!
 
-g_worker_network_timeout = 5
+g_minion_network_timeout = 5
 
-g_celeryworkerkwargs = None
+g_celery_worker_kwargs = None

--- a/src/globals.py
+++ b/src/globals.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 ################################################################################
 # This module contains global variables used by a single instance.

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import argparse
 import json

--- a/src/rule_handling.py
+++ b/src/rule_handling.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import hashlib
 import os

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import datetime
 import glob

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -99,17 +99,17 @@ compiled_rules_hash = None
 compiled_rules_lock = ReadWriteLock()
 
 
-def add_worker_arguments(parser) -> None:
+def add_minion_arguments(parser) -> None:
     """
-    Add yara worker configuration option.
+    Add yara min minion configuration option.
     :param parser: option parser
     """
     parser.add_argument(
-        "--config-file", default="yara_worker.conf", help="Yara Worker Config"
+        "--config-file", default="yara_minion.conf", help="Yara minion config"
     )
 
 
-app.user_options["worker"].add(add_worker_arguments)
+app.user_options["worker"].add(add_minion_arguments)
 
 
 class MyBootstep(bootsteps.Step):
@@ -118,7 +118,7 @@ class MyBootstep(bootsteps.Step):
     """
 
     # noinspection PyUnusedLocal
-    def __init__(self, worker, config_file="yara_worker.conf", **options):
+    def __init__(self, minion, config_file="yara_minion.conf", **options):
         super().__init__(self)
         ConfigurationInit(config_file, None)
 
@@ -166,10 +166,10 @@ def update_yara_rules_remote(yara_rules: dict) -> None:
 # Caller is obliged to compiled_rules_lock.release_read()
 def update_yara_rules():
     """
-        gets a read-acess on the in-memory set of yara rules , which are locked with multiple possible readers
-        if there is no current in memory reference to the current yara rules
-        this function attemps to read the yara-rules directory on the worker, and a produce a new set of compiled rules
-        the rules are written to disk so that other workers can load them from disk rather than re-compiling them
+    gets a read-access on the in-memory set of yara rules , which are locked with multiple possible readers
+    if there is no current in memory reference to the current yara rules
+    this function attempts to read the yara-rules directory on the minion, and a produce a new set of compiled rules
+    the rules are written to disk so that other minions can load them from disk rather than re-compiling them
     """
     global compiled_yara_rules
     global compiled_rules_hash
@@ -179,7 +179,7 @@ def update_yara_rules():
     if compiled_yara_rules:
         logger.debug("Reading the Compiled rules")
     else:
-        logger.debug("Updating yara rules in worker(s)")
+        logger.debug("Updating Yara rules in minion(s)")
         yara_rule_map = generate_rule_map(globals.g_yara_rules_dir)
         generate_yara_rule_map_hash(globals.g_yara_rules_dir)
         md5sum = hashlib.md5()
@@ -190,7 +190,7 @@ def update_yara_rules():
         compiled_rules_filepath = os.path.join(
             globals.g_yara_rules_dir, ".YARA_RULES_{0}".format(rules_hash)
         )
-        logger.debug("yara rule path is {0}".format(compiled_rules_filepath))
+        logger.debug("Yara rule path is {0}".format(compiled_rules_filepath))
 
         rules_already_exist = os.path.exists(compiled_rules_filepath)
         if not rules_already_exist:
@@ -209,7 +209,7 @@ def update_yara_rules():
             new_rules_object.save(compiled_rules_filepath)
         compiled_yara_rules = new_rules_object
         compiled_rules_hash = rules_hash
-        logger.debug("Succesfully updated yara rules")
+        logger.debug("Successfully updated Yara rules")
         compiled_rules_lock.release_write()
         compiled_rules_lock.acquire_read()
     # logger.debug("Exiting update routine ok")
@@ -228,11 +228,11 @@ def get_binary_by_hash(url: str, hsum: str, token: str):
         headers=headers,
         stream=True,
         verify=False,
-        timeout=globals.g_worker_network_timeout,
+        timeout=globals.g_minion_network_timeout,
     )
     if response:
         with zipfile.ZipFile(io.BytesIO(response.content)) as the_binary_zip:
-            # the response contains the file ziped in 'filedata'
+            # the response contains the file zipped in 'filedata'
             fp = the_binary_zip.open("filedata")
             the_binary_zip.close()
             return fp
@@ -263,7 +263,7 @@ def analyze_binary(md5sum: str) -> AnalysisResult:
         )
 
         if not binary_data:
-            logger.debug(f"No binary agailable for {md5sum}")
+            logger.debug(f"No binary available for {md5sum}")
             analysis_result.binary_not_available = True
             return analysis_result
 
@@ -312,7 +312,7 @@ def analyze_binary(md5sum: str) -> AnalysisResult:
 
 def get_high_score(matches) -> int:
     """
-    Find the higest match score.
+    Find the highest match score.
 
     :param matches: List of rule matches.
     :return: highest score

--- a/test/rules/test.yara
+++ b/test/rules/test.yara
@@ -1,7 +1,7 @@
 rule test
 {
     meta:
-        author = "Bit9 + Carbon Black <dev-support@bit9.com>"
+        author = "VMware Carbon Black (http://carbonblack.com/resources/support)"
         date = "2015/08"
         filetype = "exe"
         testing = "yep"

--- a/test/test_cbFeed.py
+++ b/test/test_cbFeed.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 from unittest import TestCase
 

--- a/test/test_cbFeedInfo.py
+++ b/test/test_cbFeedInfo.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 from unittest import TestCase
 

--- a/test/test_cbReport.py
+++ b/test/test_cbReport.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import time
 from unittest import TestCase

--- a/test/test_configCore.py
+++ b/test/test_configCore.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import os
 import shutil

--- a/test/test_configInit.py
+++ b/test/test_configInit.py
@@ -13,7 +13,7 @@ TESTS = os.path.abspath(os.path.dirname(__file__))
 
 TESTCONF = os.path.join(TESTS, "conf-testing.conf")
 BASE = """[general]
-mode=master
+mode=primary
 
 cb_server_url=https://127.0.0.1:443
 cb_server_token=abcdefghijklmnopqrstuvwxyz012345
@@ -38,7 +38,7 @@ utility_debug=false
 
 feed_database_dir=./feed_db
 
-worker_network_timeout=5
+minion_network_timeout=5
 database_scanning_interval=360
 
 celery_worker_kwargs={"autoscale":"4,4"}
@@ -75,9 +75,9 @@ class TestConfigurationInit(TestCase):
         globals.g_utility_script = ""
         globals.g_utility_debug = False
         globals.g_feed_database_dir = "./feed_db"
-        globals.g_worker_network_timeout = 5
+        globals.g_minion_network_timeout = 5
         globals.g_scanning_interval = 360
-        globals.g_celeryworkerkwargs = None
+        globals.g_celery_worker_kwargs = None
 
         with open(TESTCONF, "w") as fp:
             fp.write(BASE)
@@ -135,9 +135,9 @@ class TestConfigurationInit(TestCase):
         ConfigurationInit(TESTCONF, "sample.json")
         self.assertTrue(globals.g_output_file.endswith("sample.json"))
 
-    def test_00b_validate_config_worker(self):
+    def test_00b_validate_config_minion(self):
         """
-        Ensure our base configuration is valid for worker types.
+        Ensure our base configuration is valid for minion types.
         """
         ConfigurationInit(TESTCONF)
         self.assertTrue(globals.g_output_file.endswith("feed.json"))
@@ -178,11 +178,11 @@ class TestConfigurationInit(TestCase):
 
     def test_03a_mode_missing(self):
         """
-        Ensure we detect a configuration file without a 'mode' definition (defaults to "master")
+        Ensure we detect a configuration file without a 'mode' definition (defaults to "primary")
         """
         self.mangle(change={"mode": None})
         ConfigurationInit(TESTCONF)
-        self.assertEqual("master", globals.g_mode)
+        self.assertEqual("primary", globals.g_mode)
 
     def test_03b_mode_invalid(self):
         """
@@ -191,12 +191,12 @@ class TestConfigurationInit(TestCase):
         self.mangle(change={"mode": "bogus"})
         with self.assertRaises(CbInvalidConfig) as err:
             ConfigurationInit(TESTCONF)
-        assert "does not specify an allowed value: ['master', 'worker', 'master+worker']" in "{0}".format(
-            err.exception.args[0])
+        assert "does not specify an allowed value: ['master', 'worker', 'master+worker', " \
+               "'primary', 'minion', 'primary+minion']" in "{0}".format(err.exception.args[0])
 
     def test_03c_mode_duplicated(self):
         """
-        Ensure we detect a configuration file with a duplicate 'mode' defintion (same logic applies
+        Ensure we detect a configuration file with a duplicate 'mode' definition (same logic applies
         to all parameter duplicates).
         """
         self.mangle(add=["mode=bogus"])
@@ -206,54 +206,54 @@ class TestConfigurationInit(TestCase):
 
     # test_04 worker_type removed
 
-    def test_05a_cb_server_url_missing_for_master(self):
+    def test_05a_cb_server_url_missing_for_minion(self):
         """
-        Ensure that 'cb_server_url' is not required if mode==master
+        Ensure that 'cb_server_url' is not required if mode==primary
         """
-        self.mangle(change={"mode": "master", "cb_server_url": None})
+        self.mangle(change={"mode": "primary", "cb_server_url": None})
         ConfigurationInit(TESTCONF)
         self.assertEqual("", globals.g_cb_server_url)
 
-    def test_05b_cb_server_url_empty_for_master(self):
+    def test_05b_cb_server_url_empty_for_primary(self):
         """
-        Ensure that 'cb_server_url' is not required if mode==master
+        Ensure that 'cb_server_url' is not required if mode==primary
         """
-        self.mangle(change={"mode": "master", "cb_server_url": ""})
+        self.mangle(change={"mode": "primary", "cb_server_url": ""})
         ConfigurationInit(TESTCONF)
         self.assertEqual("", globals.g_cb_server_url)
 
-    def test_05c_cb_server_url_missing_for_worker(self):
+    def test_05c_cb_server_url_missing_for_minion(self):
         """
-        Ensure that 'cb_server_url' is required and detected if mode=worker.
+        Ensure that 'cb_server_url' is required and detected if mode=minion.
         """
-        self.mangle(change={"mode": "worker", "cb_server_url": None})
+        self.mangle(change={"mode": "minion", "cb_server_url": None})
         with self.assertRaises(CbInvalidConfig) as err:
             ConfigurationInit(TESTCONF)
         assert "has no 'cb_server_url' definition" in "{0}".format(err.exception.args[0])
 
-    def test_05d_cb_server_url_empty_for_worker(self):
+    def test_05d_cb_server_url_empty_for_minion(self):
         """
-        Ensure that 'cb_server_url' is required and detected if mode=worker.
+        Ensure that 'cb_server_url' is required and detected if mode=minion.
         """
-        self.mangle(change={"mode": "worker", "cb_server_url": ""})
+        self.mangle(change={"mode": "minion", "cb_server_url": ""})
         with self.assertRaises(CbInvalidConfig) as err:
             ConfigurationInit(TESTCONF)
         assert "has no 'cb_server_url' definition" in "{0}".format(err.exception.args[0])
 
-    def test_05e_cb_server_url_missing_for_master_worker(self):
+    def test_05e_cb_server_url_missing_for_primary_minion(self):
         """
-        Ensure that 'cb_server_url' is not required if mode==master+worker
+        Ensure that 'cb_server_url' is not required if mode==primary+minion
         """
-        self.mangle(change={"mode": "master+worker", "cb_server_url": None})
+        self.mangle(change={"mode": "primary+minion", "cb_server_url": None})
         with self.assertRaises(CbInvalidConfig) as err:
             ConfigurationInit(TESTCONF)
         assert "has no 'cb_server_url' definition" in "{0}".format(err.exception.args[0])
 
-    def test_05f_cb_server_url_empty_for_master_worker(self):
+    def test_05f_cb_server_url_empty_for_primary_minion(self):
         """
-        Ensure that 'cb_server_url' is not required if mode==master+worker
+        Ensure that 'cb_server_url' is not required if mode==primary+minion
         """
-        self.mangle(change={"mode": "master+worker", "cb_server_url": ""})
+        self.mangle(change={"mode": "primary+minion", "cb_server_url": ""})
         with self.assertRaises(CbInvalidConfig) as err:
             ConfigurationInit(TESTCONF)
         assert "has no 'cb_server_url' definition" in "{0}".format(err.exception.args[0])
@@ -665,31 +665,31 @@ class TestConfigurationInit(TestCase):
             ConfigurationInit(TESTCONF, "sample.json")
         assert "cannot be parsed" in "{0}".format(err.exception.args[0])
 
-    def test_22a_worker_network_timeout_missing(self):
+    def test_22a_minion_network_timeout_missing(self):
         """
-        Ensure that config with missing worker_network_timeout reverts to default
+        Ensure that config with missing minion_network_timeout reverts to default
         """
-        check = globals.g_worker_network_timeout
+        check = globals.g_minion_network_timeout
 
-        self.mangle(change={"worker_network_timeout": None})
+        self.mangle(change={"minion_network_timeout": None})
         ConfigurationInit(TESTCONF, "sample.json")
-        self.assertEqual(check, globals.g_worker_network_timeout)
+        self.assertEqual(check, globals.g_minion_network_timeout)
 
-    def test_22b_worker_network_timeout_empty(self):
+    def test_22b_minion_network_timeout_empty(self):
         """
-        Ensure that config with empty worker_network_timeout reverts to default
+        Ensure that config with empty minion_network_timeout reverts to default
         """
-        check = globals.g_worker_network_timeout
+        check = globals.g_minion_network_timeout
 
-        self.mangle(change={"worker_network_timeout": ""})
+        self.mangle(change={"minion_network_timeout": ""})
         ConfigurationInit(TESTCONF, "sample.json")
-        self.assertEqual(check, globals.g_worker_network_timeout)
+        self.assertEqual(check, globals.g_minion_network_timeout)
 
-    def test_22c_worker_network_timeout_bogus(self):
+    def test_22c_minion_network_timeout_bogus(self):
         """
-        Ensure that config with bogus (non-int) worker_network_timeout is detected.
+        Ensure that config with bogus (non-int) minion_network_timeout is detected.
         """
-        self.mangle(change={"worker_network_timeout": "BOGUS"})
+        self.mangle(change={"minion_network_timeout": "BOGUS"})
         with self.assertRaises(ValueError) as err:
             ConfigurationInit(TESTCONF, "sample.json")
         assert "invalid literal for int" in "{0}".format(err.exception.args[0])
@@ -772,9 +772,9 @@ class TestConfigurationInit(TestCase):
         Ensure that basic celery worker config is handled
         """
         ConfigurationInit(TESTCONF, "sample.json")
-        self.assertEqual(1, len(globals.g_celeryworkerkwargs))
-        self.assertTrue("autoscale" in globals.g_celeryworkerkwargs)
-        self.assertEqual("4,4", globals.g_celeryworkerkwargs['autoscale'])
+        self.assertEqual(1, len(globals.g_celery_worker_kwargs))
+        self.assertTrue("autoscale" in globals.g_celery_worker_kwargs)
+        self.assertEqual("4,4", globals.g_celery_worker_kwargs['autoscale'])
 
     def test_25b_celery_worker_config_bad_json(self):
         """
@@ -790,7 +790,7 @@ class TestConfigurationInit(TestCase):
         Ensure that basic celery worker config is handled when missing
         """
         self.mangle(change={"celery_worker_kwargs": None})
-        self.assertEqual(None, globals.g_celeryworkerkwargs)
+        self.assertEqual(None, globals.g_celery_worker_kwargs)
 
     # ----- Unknown configuration (typo detection)
 
@@ -809,7 +809,7 @@ class TestConfigurationInit(TestCase):
         """
         Ensure that minimal configuration does not set extra globals
         """
-        self.mangle(change={"mode": "worker"})
+        self.mangle(change={"mode": "minion"})
         globals.g_postgres_host = None
         ConfigurationInit(TESTCONF)
         self.assertIsNone(globals.g_postgres_host)

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 from unittest import TestCase
 

--- a/test/test_ruleHandler.py
+++ b/test/test_ruleHandler.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import os
 from unittest import TestCase
@@ -16,9 +16,9 @@ class TestRuleHandler(TestCase):
         check = generate_yara_rule_map_hash(os.path.join(TESTS, "rules"))
         self.assertIsNone(check)
         self.assertEqual(1, len(globals.g_yara_rule_map_hash_list))
-        self.assertEqual("191cc0ea3f9ef90ed1850a3650cd38ed", globals.g_yara_rule_map_hash_list[0])
+        self.assertEqual("d6f812c437ec1d565f068368699a1985", globals.g_yara_rule_map_hash_list[0])
 
     def test_01b_generate_yara_rule_map_hash(self):
         the_list = generate_yara_rule_map_hash(os.path.join(TESTS, "rules"), return_list=True)
         self.assertEqual(1, len(the_list))
-        self.assertEqual("191cc0ea3f9ef90ed1850a3650cd38ed", the_list[0])
+        self.assertEqual("d6f812c437ec1d565f068368699a1985", the_list[0])

--- a/test/test_tasks.py
+++ b/test/test_tasks.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-# Copyright © 2014-2019 VMware, Inc. All Rights Reserved.
+# Copyright © 2014-2020 VMware, Inc. All Rights Reserved.
 
 import os
 from unittest import TestCase


### PR DESCRIPTION
Notable configuration changes:

- deprecated terms "master" and "worker" in favor of "primary" and "minion"
- the deprecated terms still work, to preserve backward compatibility for customer with existing installations

Note: because we're using third-party software (celery) that uses the term worker, both as a terminology and in the names of API calls, I am not changing config options or other things that directly refer to that software. We need to be internally consistent, but my position is that we should remain consistent with third-party code as well, to avoid confusion.