### PR TITLE
[bugfix] rules without score not generating alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ cb_server_token=<API TOKEN GOES HERE>
 ## Create your YARA rules
 
 The YARA connector monitors the directory `/etc/cb/integrations/cb-yara-connector/yara_rules` for files (`.yar`) each 
-specifying one or more YARA rule. Your rules must have `meta` section with a 
-`score = [1-10]` tag to appropriately score matching binaries.  This directory is 
-configurable in your configuration file. C-style comments are supported.
+specifying one or more YARA rule. Your rules should have a `meta` section with a
+`score = [1-100]` tag to appropriately score matching binaries.  Rules with no score defined will default to 100.
+This directory is configurable in your configuration file. C-style comments are supported.
 
 ### Sample YARA Rule File
 ```

--- a/src/cbopensource/connectors/yara_connector/tasks.py
+++ b/src/cbopensource/connectors/yara_connector/tasks.py
@@ -301,7 +301,7 @@ def analyze_binary(md5sum: str, node_id=0) -> AnalysisResult:
 
 def get_high_score(matches) -> int:
     """
-    Find the highest match score.
+    Find the highest match score. If score is unset, default to 100.
 
     :param matches: List of rule matches.
     :return: highest score
@@ -312,7 +312,7 @@ def get_high_score(matches) -> int:
 
     score = -1
     for match in matches:
-        if match.meta.get("score", 0) > score:
+        if match.meta.get("score", -1) > score:
             score = match.meta.get("score")
     if score == -1:
         return 100


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:

- [X] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [X] Tests have been added that prove the fix is effective or that the feature works.
- [X] New and existing tests pass locally with the changes.
- [X] Code follows the style guidelines of this project (PEP8, clean code).
- [X] Linter has passed locally and any fixes were made for failures.
- [X] A self-review of the code has been done.

## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix

## What is the ticket or issue number?
- `CB-41404`

## Pull Request Description
Per [this](https://community.carbonblack.com/t5/Knowledge-Base/EDR-How-To-Validate-Yara-Rules/ta-p/85231:) CB Knowledge Base article and what I'm assuming is the intent of the `get_high_score` function [here](https://github.com/carbonblack/cb-yara-connector/blob/8f4a39fadae123a11d47673f8c9407fd66b97d44/src/cbopensource/connectors/yara_connector/tasks.py#L313-L320):

> If there is no "score" value assigned by the rule, but a hit is determined, it will get a default score of 100

However, there is a bug in the `get_high_score` function. Since `match.meta.get("score", 0)` evaluates to `0` if "score" is unset in the rule, but "score" is set to `-1` before this loop, the condition will always evaluate to True. Thus, the following line `match.meta.get("score")` sets score to `None` and the `return 100` [line](https://github.com/carbonblack/cb-yara-connector/blob/8f4a39fadae123a11d47673f8c9407fd66b97d44/src/cbopensource/connectors/yara_connector/tasks.py#L318) is unreachable.

This has the effect of causing rules without a score set **to not generate any alerts**. It appears the bug was introduced in this change: https://github.com/carbonblack/cb-yara-connector/commit/35afcac8908db95850d66b45f2933bf7f1bea601 -- when the default score value was changed from `0` to `1`, the condition was not updated along with it.

While the README indicates: "Your rules must have meta section with a score = [1-10] tag to appropriately score matching binaries", this conflicts with the guidance given in the KB article, the (assumed) intent of the `get_high_score` function and the fact that CB seems to score alerts from 1-100 -- thus, I have updated the README as well.



## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## How Has This Been Tested?

Buggy behavior confirmed locally with test yara rules (with and without `score` values). New mock test added to simulate a rule with an empty `meta` section and thus no set "score" value. Have not yet been able to create manual rpm package to test this fix directly on a CB server.